### PR TITLE
Remove Ruby 1.8.7 support from Rubocop

### DIFF
--- a/.rubocop_cocoapods.yml
+++ b/.rubocop_cocoapods.yml
@@ -50,22 +50,8 @@ GuardClause:
 Next:
   Enabled: false
 
-#- CocoaPods support for Ruby 1.8.7 ------------------------------------------#
-
 HashSyntax:
   EnforcedStyle: hash_rockets
-
-Lambda:
-  Enabled: false
-
-DotPosition:
-  EnforcedStyle: trailing
-
-EachWithObject:
-  Enabled: false
-
-Style/SpecialGlobalVars:
-  Enabled: false
 
 #- CocoaPods specs -----------------------------------------------------------#
 


### PR DESCRIPTION
I left hash rockets. Because. hash rockets are awesome. :rocket:.

/cc @alloy 