### PR TITLE
Add pr exists label

### DIFF
--- a/scripts/setup-github-labels.rb
+++ b/scripts/setup-github-labels.rb
@@ -25,7 +25,7 @@ LABELS = {
   "s3:detailed" => "E28C2C",
   "s4:awaiting validation" => "F97D27",
   "s5:blocked" => "684324",
-  "s6:PR exists" => "FAD8C7",
+  "s6:pr exists" => "FAD8C7",
 
   # Difficulty
   "d1:easy" => "00B952",
@@ -36,7 +36,7 @@ LABELS = {
   "★" => "C7C1C1",
 
   # Other
-  "Frameworks" => "E11D21",
+  "frameworks" => "E11D21",
 }
 
 MAPPINGS = {

--- a/scripts/setup-github-labels.rb
+++ b/scripts/setup-github-labels.rb
@@ -1,7 +1,7 @@
 require 'octokit'
 
 token_file = File.expand_path("../../.github_access_token", File.dirname(__FILE__))
-token = File.file?(token_file) ? File.read(token_file).strip : ''
+token = File.file?(token_file) ? File.read(token_file).strip : ENV['GITHUB_API_TOKEN']
 repo_slug = ARGV.first
 dry_run = ARGV.include?('--dry-run')
 

--- a/scripts/setup-github-labels.rb
+++ b/scripts/setup-github-labels.rb
@@ -17,6 +17,7 @@ LABELS = {
   "t2:defect" => "6902E1",
   "t3:discussion" => "E10288",
   "t4:internal" => "0D00D9",
+  "t5:plugin idea" => "D4C5F9",
 
   # Status
   "s1:awaiting input" => "EDCE24",
@@ -33,6 +34,9 @@ LABELS = {
 
   # Priority
   "★" => "C7C1C1",
+
+  # Other
+  "Frameworks" => "E11D21",
 }
 
 MAPPINGS = {

--- a/scripts/setup-github-labels.rb
+++ b/scripts/setup-github-labels.rb
@@ -24,6 +24,7 @@ LABELS = {
   "s3:detailed" => "E28C2C",
   "s4:awaiting validation" => "F97D27",
   "s5:blocked" => "684324",
+  "s6:PR exists" => "FAD8C7",
 
   # Difficulty
   "d1:easy" => "00B952",


### PR DESCRIPTION
Mostly adds a "pr exists" label. This is supposed to mark issues for which an unmerged PR already exists. This both helps us to determine which open issues to look at, as well as users to look for that PR link / comment somewhere in the issue.

Also now optionally reads the GH API token from an environment variable for those of us who don't want extra files :)

Finally, adds two labels which were apparently added manually at some point.