### PR TITLE
Update shared Rubocop file

### DIFF
--- a/.rubocop_cocoapods.yml
+++ b/.rubocop_cocoapods.yml
@@ -4,6 +4,7 @@ require:
 AllCops:
   Include:
     - lib/**/*.rb
+    - spec/**/*.rb
     - Rakefile
     - Gemfile
     - "*.gemspec"


### PR DESCRIPTION
This updated Rubocop file designed for latest Rubocop (1.8 at time)

Notable change:

- Performance linting rules extract to a standalone gem
- Cops' namespace update
- `AllCops/Include` is a whitelist in newer version, so must add `lib/**/*.rb`
- Looks like `./` has problem, remove them, this should no harm